### PR TITLE
Add makefile.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,19 @@
+CC=gcc
+CXX=g++
+RM=rm -f
+
+SRCS=hitime.cpp
+OBJS=$(subst .cpp,.o,$(SRCS))
+
+all: hitime.out
+
+hitime.out: $(OBJS)
+	$(CXX) -o hitime.out $(OBJS)
+
+hitime.o: hitime.cpp
+
+clean:
+	$(RM) $(OBJS)
+
+dist-clean: clean
+	$(RM) hitime.out


### PR DESCRIPTION
Running `make` will produce the 'hitime.out' executable, `make
clean` removes '.o' files and `make dist-clean` also removes the
executable.
