### PR TITLE
Fix README and add SLURM script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,26 +25,18 @@ correctly with other versions of gcc such as 4.8.1.
     module load boost-gcc/1.57.0
 ```
 
-### Step 3: Linker path
-
-In order to run the compiled program the ProteoWizard libraries must be able
-to be located. This is done by adding them to the `LD_LIBRARY_PATH` 
-environment variable.
-
-`export LD_LIBRARY_PATH=/usr/local/pwiz/3.0.7069-gcc/lib/:$LD_LIBRARY_PATH`
-
-### Step 4: Compile
+### Step 3: Compile
 
 Running `make` in the HiTIME-CPP directory should be sufficent to build the
 `hitime.out` binary. It may be necessary to modify the `INC` and `LIBDIR`
 variables in `makefile` if your library locations are different.
 
-### Step 5: Test
+### Step 4: Test
 
 Test data is included in this repository. Running the following command
-should produce meaningful output.
+should produce meaningful output saved in out.txt:
 
-`./hitime.out data/testing.mzML`
+`./hitime.out data/testing.mzML out.txt`
 
 ## Please Note:
 
@@ -52,4 +44,3 @@ HiTIME-CPP is currently under active development, as such functionality can
 be expected to change frequently and without notice. These instructions have
 been designed for the developement setup and may require significant
 modification on your system.
-

--- a/job.slurm
+++ b/job.slurm
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Created by the VLSCI job script generator for SLURM on x86
+# Mon Feb 09 2015 22:01:44 GMT+1100 (AEDT)
+
+# check that the script is launched with sbatch
+if [ "x$SLURM_JOB_ID" == "x" ]; then
+   echo "You need to submit your job to the queuing system with sbatch"
+   exit 1
+fi
+
+# Partition for the job:
+#SBATCH -p main
+
+# The name of the job:
+#SBATCH --job-name="hitime-cpp"
+
+# Maximum number of CPU cores used by the job:
+#SBATCH --ntasks=1
+
+# The amount of memory in megabytes per process in the job:
+#SBATCH --mem-per-cpu=24576
+
+# Send yourself an email when the job:
+# aborts abnormally (fails)
+#SBATCH --mail-type=FAIL
+# ends successfully
+#SBATCH --mail-type=END
+
+# The maximum running time of the job in days-hours:mins:sec
+#SBATCH --time=0-24:0:00
+
+# Run the job from the directory where it was launched (default):
+# The job command(s):
+
+module load boost-gcc/1.57.0
+module load pwiz-gcc/3.0.7069
+#./hitime.out data/testing.mzML testing.txt
+./hitime.out data/rat.mzML rat.out


### PR DESCRIPTION
I fixed the module for pwiz so that it sets LD_LIBRARY_PATH correctly.

This means we no longer need to set it ourselves at the command line. I've updated the README to reflect this.

I also added an output filename to the example command line in the README.

I've added an example SLURM script for running jobs on the cluster.